### PR TITLE
Css fixes

### DIFF
--- a/html/YANPIWS.js
+++ b/html/YANPIWS.js
@@ -34,14 +34,21 @@ function loadXMLDoc(URL, targetId, callback) {
 // todo - use class for defaultSize, remove from signature
 function setClockSize(state, defaultSize){
     if (state == 'big'){
-        // todo - put all this in a class and then just add and remove class
-        $('#time').css('font-size', '127pt').css('text-align', 'center').css('width', '100%');
-        $('#date').css('text-align', 'center').css('width', '100%');
+        $('#time').removeClass("small_time")
+        $('#date').removeClass("small_time")    
+        $('#datetimewind').removeClass("small_time_parent")      
+        $('#time').addClass("big_time")
+        $('#date').addClass("big_time")
+
         $('.big_clock_hide').hide();
+        console.log('using big size');
     } else {
-        // todo - put all this in a class and then just add and remove class
-        $('#time').css('font-size', defaultSize + 'pt').css('text-align', 'left').css('width', 'inherit');
-        $('#date').css('text-align', 'left').css('width', 'inherit');
+        $('#time').removeClass("big_time")
+        $('#date').removeClass("big_time")   
+        $('#datetimewind').addClass("small_time_parent")           
+        $('#time').addClass("small_time")
+        $('#date').addClass("small_time")        
+
         $('.big_clock_hide').show();
         console.log('using small size: ' + defaultSize);
     }

--- a/html/index.php
+++ b/html/index.php
@@ -50,10 +50,12 @@ foreach ($YANPIWS['labels'] as $id => $label) {
 <div class="col">
     <div class="row"></div>
     <div class="row ">
-        <div id="wind_now" class="wind_now big_clock_hide"></div>
-        <div  id="datetime">
-            <div id='time'></div>
-            <div id='date'></div>
+        <div id='datetimewind' class='small_time_parent'>
+            <div id="wind_now" class="wind_now small_time">31 mph</div>     
+            <div id='datetime'>
+                <div id='time' class='small_time'></div>
+                <div id='date' class='small_time'></div>
+            </div>
         </div>
     </div>
     <div class="row suntimes big_clock_hide">
@@ -66,7 +68,7 @@ foreach ($YANPIWS['labels'] as $id => $label) {
 <span id="last_ajax"></span>
 <script>
     var clockState = 'small';
-    clockState = $( "#datetime" ).click(function() {
+    $( "#datetime" ).click(function() {
         if (clockState == 'small'){
             clockState = 'big';
         } else {

--- a/html/styles.css.php
+++ b/html/styles.css.php
@@ -84,26 +84,57 @@ a.yellow {
     width:25px;
     padding-left:20px;
 }
-#date, #time, .label, .wind_now {
+
+.label, .wind_now {
     font-size:<?= $YANPIWS['font_time_date_wind']?>pt;
     font-weight: bold;
 }
 
+.big_time {
+    font-size: 127pt;
+    text-align: center;
+    width: 100%;
+}
+
+.small_time {
+    font-size: <?= $YANPIWS['font_time_date_wind']?>pt;
+    text-align: left;
+    width: fit-content;
+    padding: 5px;
+    display: inline-block;
+}
+
+.small_time_parent {
+    width: 100%;
+}
+
+.big_clock_hide {
+    display: block;
+}
+
 .label {
     text-transform: uppercase;
-    font-size: <?= $YANPIWS['font_temp_label']?>pt;
 }
-#date, #time{
-    float: left;
+#date, #time, #wind_now{
+    font-weight: bold;
 }
+
 #time:hover{
     cursor: pointer;
 }
 .wind_now {
+    width: fit-content;
+    display: inline-block;
     float: right;
+    padding-left: 30px;
 }
+
+#datetime {
+    display: block;
+}
+
 #date {
-    padding-left: 20px;
+    padding-left: 30px;
 }
 .lowt {
     color: #476b6b;


### PR DESCRIPTION
A few fixes happened in this commit: 

**YANPIWS.js**: "setClockSize"  now add and remove classes instead of modifying css directly. 

**Index.php**:  This had two modifications:
1. classes added to original <div> to coincide with YANPIWS.js changes
2. A bug where you had to click the clock twice to enable "big clock" mode was fixed. Variable clockState was set twice the first time the function was run. 

**styles.css.php**: Added classes "big_time", "small_time", and "small_time_parent". Also added some padding to the date, time, and wind <div> blocks.

Note that I could have just added padding to the wind parameter because the original reason I made this pull request was because there was an issue when the screen was too narrow (e.g. ipad) and it didn't trigger the date to go onto a newline. The result was the wind speed and date combining to look like a tornado was happening when a user glanced at the screen. The javascript and css fixes outside of this fix just happened to look interesting and simple enough to fix. 

