### PR TITLE
Support other forecast APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv
 config.php
 config.csv
 datadarksky.cache
+forecast.cache

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ to DIY a weather station.
 
 Goals for this project are:
 
-* Use cheap hardware (e.g. Rasberry Pi)
+* Use cheap hardware (e.g. Rasberry Pi from 2017)
 * Show live weather from local, wireless sensors
 * Show time
 * Show today's sunset/sunrise times
-* Show weather forecast from [Dark Sky API](https://darksky.net/dev/)
+* Show weather forecast from a forecast API ([Dark Sky](https://darksky.net/dev/) or  [Pirate Weather](pirateweather.net/))
 
 ## Hardware
 
@@ -32,7 +32,7 @@ Here's the parts I used and prices at time of publishing (March 2017):
 * $43 - [Rasberry Pi 3 Model B and Power Adapter](http://amzn.to/2nklto3)
 * $11 - [8GB Micro SD card](http://amzn.to/2nRE9Pt)
 
-Total for this is $127, so, erm, not that cheap.  Ideally you'd have a lot of 
+Total for this is $127, so, erm, not _that_ cheap.  Ideally you'd have a lot of 
 parts around you could re-use for this project. As well, you could reduce the price by going with a 
 3.5" screen ([only $17](http://amzn.to/2mCIxlg)) and Pi B+ ([only $30](http://amzn.to/2n5nioJ))
 . For the B+ you'd have to use ethernet or bring your own USB WiFi 
@@ -128,7 +128,7 @@ of creating your own config file.  Here we see ID 231:
 Specifically, your latitude (`lat`),
 longitude (`lon`) and labels which you 
 got in the step above running `rtl_433`. As well, you'll need to sign up for an API key
-on [Dark Sky](https://darksky.net/dev/register) and put that in for the `darksky` value below. 
+on [Dark Sky](https://darksky.net/dev/register) or [Pirate Weather](pirateweather.net/) and put that in for the `forecast_api` value below. 
 If you want static icons instead of
 animated ones, set 'animate' to `false` instead of `true` like below. Here's a sample:
     ```
@@ -137,8 +137,8 @@ animated ones, set 'animate' to `false` instead of `true` like below. Here's a s
     lat,31.775554
     lon,-81.822436
     
-    # set your darksky API token - should be a 32 char alpa numeric
-    darksky,aabbccddeeffgghhiijj112233445566
+    # set your forecast API token - should be a 32 char alpa numeric
+    forecast_api,aabbccddeeffgghhiijj112233445566
     
     # should we show animated icons for forecast? should be "true" or "false"
     animate,true
@@ -295,10 +295,10 @@ IP address of your server:
 
 ## Development
 
-Check out this repo, ``cd`` into and start a web server:
+Check out this repo, `cd` into the `html` directory and start a web server:
 
 ```
-sudo php -S  localhost:8000
+php -S  localhost:8000
 ```
 
 The rtl_433 works great on Ubuntu for desktop/laptop development.  Manually kick off the input 
@@ -339,6 +339,9 @@ Use your IDE of choice to edit and point your browser at ``localhost:8000``
 PRs and Issues welcome!
 
 ## Version History
+* 0.10.0 - Apr 3,2023
+  * Support Pirate Weather by default #69
+  * Move to SemVer versioning (MAJOR.MINOR.PATCH)
 * 0.9.10 - Jul 20,2020
   * Convert to more JSON, less HTML over AJAX calls #89
   * Allow big clock mode by clicking time #82

--- a/README.md
+++ b/README.md
@@ -137,8 +137,11 @@ animated ones, set 'animate' to `false` instead of `true` like below. Here's a s
     lat,31.775554
     lon,-81.822436
     
-    # set your forecast API token - should be a 32 char alpa numeric
-    forecast_api,aabbccddeeffgghhiijj112233445566
+    # set your forecast API token - should be a 32-40 char alpha numeric
+    forecast_api_token,aabbccddeeffgghhiijj112233445566
+   
+    # set your forecast API URL
+    forecast_api_url,https://api.pirateweather.net
     
     # should we show animated icons for forecast? should be "true" or "false"
     animate,true

--- a/config.dist.csv
+++ b/config.dist.csv
@@ -3,8 +3,13 @@
 lat,31.775554
 lon,-81.822436
 
-# set your darksky API token - should be a 32 char alpa numeric
-darksky,aabbccddeeffgghhiijj112233445566
+# set your forecast API token from either Dark Sky or Pirate Weather
+forecast_api_token,aabbccddeeffgghhiijj112233445566
+
+# set your provider for forecasts (must end in an:
+#   pirate weather: https://api.pirateweather.net
+#   dark sky: https://api.darksky.net
+forecast_api_url,https://api.pirateweather.net
 
 # should we show animated icons for forecast? should be "true" or "false"
 animate,true

--- a/html/ajax.php
+++ b/html/ajax.php
@@ -6,7 +6,7 @@ if (isset($_GET['content'])){
     $today = date('Y-m-d', time());
     $time = date('g:i A', time());
     $date = date('D M j', time());
-    $forecast = getDarkSkyData();
+    $forecast = getForecastData();
 
     switch ($_GET['content']){
         case "forecast":

--- a/html/index.php
+++ b/html/index.php
@@ -3,7 +3,7 @@ global $YANPIWS;
 require_once 'get_data.php';
 getConfig();
 
-$forecast = getDarkSkyData();
+$forecast = getForecastData();
 $status = configIsValid();
 $statusHtml = '';
 if ($status['valid'] != true) {

--- a/html/stats.php
+++ b/html/stats.php
@@ -15,7 +15,7 @@ if (isset($_SERVER['SERVER_ADDR'])) {
     $address = 'NA';
 }
 
-$darkskytime= getCacheAge();
+$cachetime= getCacheAge();
 ?>
 <!DOCTYPE html>
 <html lang="en" xmlns="http://www.w3.org/1999/html">
@@ -30,9 +30,9 @@ $darkskytime= getCacheAge();
             <a href="/" class="homeLink"><-  Weather</a>
         </p>
         <a href="https://github.com/mrjones-plip/YANPIWS">YANPIS 0.9.10</a> - Released Jul 26, 2020<br />
-        <a href="https://darksky.net/poweredby/">Powered by Dark Sky</a><br />
+        <a href="http://pirateweather.net/en/latest/#introduction/">Powered by Pirate Weather</a><br />
         <?php echo $currentTempHtml ?>
-        Dark Sky Cache Age: <?php echo $darkskytime ?><br/>
+        Forecast Cache Age: <?php echo $cachetime ?><br/>
         IP: <?php echo $address ?>
     </div>
 </div>

--- a/html/stats.php
+++ b/html/stats.php
@@ -29,7 +29,7 @@ $cachetime= getCacheAge();
         <p>
             <a href="/" class="homeLink"><-  Weather</a>
         </p>
-        <a href="https://github.com/mrjones-plip/YANPIWS">YANPIS 0.10.0</a> - Released Apr 3, 2023<br />
+        <a href="https://github.com/mrjones-plip/YANPIWS">YANPIWS 0.10.0</a> - Released Apr 3, 2023<br />
         <a href="http://pirateweather.net/en/latest/#introduction/">Powered by Pirate Weather</a><br />
         <?php echo $currentTempHtml ?>
         Forecast Cache Age: <?php echo $cachetime ?><br/>

--- a/html/stats.php
+++ b/html/stats.php
@@ -29,7 +29,7 @@ $cachetime= getCacheAge();
         <p>
             <a href="/" class="homeLink"><-  Weather</a>
         </p>
-        <a href="https://github.com/mrjones-plip/YANPIWS">YANPIS 0.9.10</a> - Released Jul 26, 2020<br />
+        <a href="https://github.com/mrjones-plip/YANPIWS">YANPIS 0.10.0</a> - Released Apr 3, 2023<br />
         <a href="http://pirateweather.net/en/latest/#introduction/">Powered by Pirate Weather</a><br />
         <?php echo $currentTempHtml ?>
         Forecast Cache Age: <?php echo $cachetime ?><br/>

--- a/html/temps.php
+++ b/html/temps.php
@@ -17,7 +17,7 @@
 <?php
 require_once 'get_data.php';
 getConfig();
-$forecast = getDarkSkyData();
+$forecast = getForecastData();
 $status = configIsValid();
 
 // get two days worth of data and merge them so we can ensure we have a


### PR DESCRIPTION
This PR adds support for other APIs that match the same format as Dark Sky's URL,  API token and blindly trust they all return the same (or similar enough) API response:

```php
$YANPIWS['forecast_api_url'] . '/forecast/' . $YANPIWS['forecast_api_token'] . '/' . $lat . ',' . $lon;
```

per #69