### PR TITLE
add new python screen for ic2

### DIFF
--- a/I2C.bme280.oled/simple_remote.py
+++ b/I2C.bme280.oled/simple_remote.py
@@ -34,8 +34,8 @@ def post_to_yanpiws(yanpiws_ip, calibration_params, bus, address):
     requests.post(url, data=data)
 
 
-def get_remote_humid_and_temp(yanpiws_ajax_url, id):
-    forecast_url = f'{yanpiws_ajax_url}humidity&id={str(id)}'
+def get_remote_humid_and_temp(yanpiws_ajax_url, temp_id):
+    forecast_url = f'{yanpiws_ajax_url}humidity&id={str(temp_id)}'
     return requests.get(forecast_url).json()
 
 

--- a/I2C.bme280.oled/simple_remote.py
+++ b/I2C.bme280.oled/simple_remote.py
@@ -16,37 +16,6 @@ from dateutil import tz
 import requests
 from datetime import datetime, timezone, timedelta
 
-parser = argparse.ArgumentParser()
-
-# Rev 2 Pi, Pi 2 & Pi 3 uses bus 1
-# Rev 1 Pi uses bus 0
-# Orange Pi Zero uses bus 0 for pins 1-5 (other pins for bus 1 & 2)
-parser.add_argument('--bus', '-b', default=0, type=int, help='Bus Number, defaults to 0')
-
-# IP address of your YANPIWS device you want to show data from
-parser.add_argument('--remote_ip', '-ip', default='192.168.68.105', type=str, help='Temp sensor ID, defaults to 0x76')
-
-# ID from your YANPIWS config.csv of temp 1
-parser.add_argument('--temp_id1', '-id1', default='143', type=int, help='remote temp ID #1, defaults to 143')
-
-args = parser.parse_args()
-
-# Build URL and set some vars
-yanpiws_ip = args.remote_ip
-yanpiws_temp_1 = args.temp_id1
-yanpiws_ajax_url = 'http://' + str(yanpiws_ip) + '/ajax.php?content='
-last_seen_temp= 0.0
-
-# set up syslog logging
-my_logger = logging.getLogger('MyLogger')
-my_logger.setLevel(logging.DEBUG)
-handler = logging.handlers.SysLogHandler(address='/dev/log')
-my_logger.addHandler(handler)
-
-# BME280 sensor address (default address), Initialize I2C bus and calibration
-address = 0x76 # can also be 0x77 - check  i2cdetect -y 1 or i2cdetect -y 0
-bus = smbus2.SMBus(1) # can also be 0, depends on where you found device on per i2cdetect
-calibration_params = bme280.load_calibration_params(bus, address)
 
 def post_to_yanpiws():
     data = bme280.sample(bus, address, calibration_params)
@@ -165,6 +134,39 @@ def main(device):
 
 if __name__ == "__main__":
     try:
+        parser = argparse.ArgumentParser()
+
+        # Rev 2 Pi, Pi 2 & Pi 3 uses bus 1
+        # Rev 1 Pi uses bus 0
+        # Orange Pi Zero uses bus 0 for pins 1-5 (other pins for bus 1 & 2)
+        parser.add_argument('--bus', '-b', default=0, type=int, help='Bus Number, defaults to 0')
+
+        # IP address of your YANPIWS device you want to show data from
+        parser.add_argument('--remote_ip', '-ip', default='192.168.68.105', type=str,
+                            help='Temp sensor ID, defaults to 0x76')
+
+        # ID from your YANPIWS config.csv of temp 1
+        parser.add_argument('--temp_id1', '-id1', default='143', type=int, help='remote temp ID #1, defaults to 143')
+
+        args = parser.parse_args()
+        
+        # Build URL and set some vars
+        yanpiws_ip = args.remote_ip
+        yanpiws_temp_1 = args.temp_id1
+        yanpiws_ajax_url = 'http://' + str(yanpiws_ip) + '/ajax.php?content='
+        last_seen_temp = 0.0
+
+        # set up syslog logging
+        my_logger = logging.getLogger('MyLogger')
+        my_logger.setLevel(logging.DEBUG)
+        handler = logging.handlers.SysLogHandler(address='/dev/log')
+        my_logger.addHandler(handler)
+
+        # BME280 sensor address (default address), Initialize I2C bus and calibration
+        address = 0x76  # can also be 0x77 - check  i2cdetect -y 1 or i2cdetect -y 0
+        bus = smbus2.SMBus(1)  # can also be 0, depends on where you found device on per i2cdetect
+        calibration_params = bme280.load_calibration_params(bus, address)
+
         my_logger.debug('Weathercaster: simple Starting ')
         serial = i2c(port=args.bus, address=0x3C)
         device = ssd1306(serial)

--- a/I2C.bme280.oled/simple_remote.py
+++ b/I2C.bme280.oled/simple_remote.py
@@ -131,7 +131,7 @@ def main():
 
         # IP address of your YANPIWS device you want to show data from
         parser.add_argument('--remote_ip', '-ip', default='192.168.68.105', type=str,
-                            help='Temp sensor ID, defaults to 0x76')
+                            help=f'Temp sensor ID, defaults to {ADDRESS}')
 
         # ID from your YANPIWS config.csv of temp 1
         parser.add_argument('--temp_id1', '-id1', default='143', type=int, help='remote temp ID #1, defaults to 143')
@@ -167,9 +167,8 @@ if __name__ == "__main__":
 
         main()
 
-
     except KeyboardInterrupt:
         my_logger.debug("Weathercaster: simple Stopping(Ctrl + C) ")
 
-    finally:
+    except:
         my_logger.debug("Weathercaster simple exit trace: " + full_stack())

--- a/I2C.bme280.oled/simple_remote.py
+++ b/I2C.bme280.oled/simple_remote.py
@@ -9,7 +9,7 @@ import argparse
 import logging.handlers
 import smbus2
 import bme280
-import os
+import pathlib
 import time
 from dateutil import tz
 import requests
@@ -92,9 +92,10 @@ def show_info(yanpiws_ajax_url, yanpiws_temp_1, device):
     if no_error and forecast[0]:
         third_line = str(int(float(forecast[0]['temperatureMax']))) + '°' + forecast[0]['icon']
 
-    full_path = os.path.dirname(os.path.abspath(__file__)) + "/"
-    font2 = ImageFont.truetype(full_path + "Lato-Heavy.ttf", 13)
-    font1 = ImageFont.truetype(full_path + "Lato-Heavy.ttf", 19)
+    # full_path = os.path.dirname(os.path.abspath(__file__)) + "/"
+    font_file = f'{pathlib.Path(__file__).parent.resolve()}/Lato-Heavy.ttf'
+    font2 = ImageFont.truetype(font_file, 13)
+    font1 = ImageFont.truetype(font_file, 19)
 
     with canvas(device) as draw:
         draw.text((0, 4), first_line, font=font2, fill="white")

--- a/I2C.bme280.oled/simple_remote.py
+++ b/I2C.bme280.oled/simple_remote.py
@@ -15,7 +15,6 @@ import time
 from dateutil import tz
 import requests
 from datetime import datetime
-import urllib.request
 
 
 def post_to_yanpiws():
@@ -36,7 +35,7 @@ def post_to_yanpiws():
 
 
 def get_string_from_url(url):
-    raw_html = urllib.request.urlopen(url).read().decode('utf-8').rstrip()
+    raw_html = requests.get(url).content
     return raw_html
 
 

--- a/I2C.bme280.oled/simple_remote.py
+++ b/I2C.bme280.oled/simple_remote.py
@@ -14,7 +14,8 @@ import os
 import time
 from dateutil import tz
 import requests
-from datetime import datetime, timezone, timedelta
+from datetime import datetime
+import urllib.request
 
 
 def post_to_yanpiws():
@@ -35,7 +36,6 @@ def post_to_yanpiws():
 
 
 def get_string_from_url(url):
-    import urllib.request
     raw_html = urllib.request.urlopen(url).read().decode('utf-8').rstrip()
     return raw_html
 

--- a/I2C.bme280.oled/simple_remote.py
+++ b/I2C.bme280.oled/simple_remote.py
@@ -83,17 +83,17 @@ def get_remote_forecast():
 def get_remote_sun():
     data = json.loads(get_string_from_url(yanpiws_ajax_url + "sunrise"))
     data.update(json.loads(get_string_from_url(yanpiws_ajax_url + "sunset")))
-    return "☀" + str(data['sunrise']) + " ○" + str(data['sunset'])
+    return "☀ ↑" + str(data['sunrise']) + " ↓" + str(data['sunset'])
 
 
 def get_remote_moon():
     data = json.loads(get_string_from_url(yanpiws_ajax_url + "moonset"))
     data.update(json.loads(get_string_from_url(yanpiws_ajax_url + "moonrise")))
-    result = '☾'
+    result = '○'
     if data['moonrise']:
-        result = result + "🡡" + data['moonrise']
+        result = result + " ↑" + data['moonrise']
     if data['moonset']:
-        result = result + " 🡣" + data['moonset']
+        result = result + " ↓" + data['moonset']
 
     my_logger.debug('moon data debug: ' + result)
     return result
@@ -123,7 +123,7 @@ def show_info(wait):
         second_line = str(int(float(humid_and_temp1[0]['temp']))) + '°' + humid_and_temp1[0]['label']
 
     if no_error and moon_all:
-        first_line2 = "↑ ↓ ☀ " + moon_all
+        first_line2 = moon_all
 
     if no_error and forecast[0]:
         third_line = str(int(float(forecast[0]['temperatureMax']))) + '°' + forecast[0]['icon']

--- a/I2C.bme280.oled/simple_remote.py
+++ b/I2C.bme280.oled/simple_remote.py
@@ -15,6 +15,7 @@ from dateutil import tz
 import requests
 from datetime import datetime
 
+WAIT = 120
 
 def post_to_yanpiws():
     data = bme280.sample(bus, address, calibration_params)
@@ -60,7 +61,7 @@ def get_remote_moon():
     return result
 
 
-def show_info(wait):
+def show_info():
 
     # fetch the cooked up json -> strings
     forecast = {}
@@ -99,14 +100,14 @@ def show_info(wait):
         draw.text((0, 30), second_line, font=font1, fill="white")
         draw.text((0, 46), third_line, font=font1, fill="white")
 
-    my_logger.debug(f"Weathercaster: simple Updated screen, posted {last_seen_temp} temp. Waiting {wait} seconds to update again.")
+    my_logger.debug(f"Weathercaster: simple Updated screen, posted {last_seen_temp} temp. Waiting {WAIT} seconds to update again.")
 
 
 def full_stack():
     import traceback, sys
     exc = sys.exc_info()[0]
     stack = traceback.extract_stack()[:-1]  # last one would be full_stack()
-    if exc is not None:  # i.e. an exception is present
+    if not exc:  # i.e. an exception is present
         del stack[-1]  # remove call of full_stack, the printed exception
         # will contain the caught exception caller instead
     trc = 'Traceback (most recent call last):\n'
@@ -118,10 +119,9 @@ def full_stack():
 
 def main(device):
     while True:
-        wait = 120
         post_to_yanpiws()
-        show_info(wait)
-        time.sleep(wait)
+        show_info()
+        time.sleep(WAIT)
 
 
 if __name__ == "__main__":

--- a/I2C.bme280.oled/simple_remote.py
+++ b/I2C.bme280.oled/simple_remote.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python3
+
+
+# grab args from CLI
+import argparse
+from luma.core.interface.serial import i2c
+from luma.core.render import canvas
+from luma.oled.device import ssd1306
+from PIL import ImageFont
+import os
+import argparse
+import json
+import time
+import logging.handlers
+
+parser = argparse.ArgumentParser()
+
+# Rev 2 Pi, Pi 2 & Pi 3 uses bus 1
+# Rev 1 Pi uses bus 0
+# Orange Pi Zero uses bus 0 for pins 1-5 (other pins for bus 1 & 2)
+parser.add_argument('--bus', '-b', default=0, type=int, help='Bus Number, defaults to 0')
+
+# IP address of your YANPIWS device you want to show data from
+parser.add_argument('--remote_ip', '-ip', default='192.168.68.105', type=str, help='Temp sensor ID, defaults to 0x76')
+
+# ID from your YANPIWS config.csv of temp 1
+parser.add_argument('--temp_id1', '-id1', default='143', type=int, help='remote temp ID #1, defaults to 143')
+
+
+args = parser.parse_args()
+
+yanpiws_ip = args.remote_ip
+yanpiws_temp_1 = args.temp_id1
+
+bus_number = args.bus
+
+my_logger = logging.getLogger('MyLogger')
+my_logger.setLevel(logging.DEBUG)
+handler = logging.handlers.SysLogHandler(address='/dev/log')
+my_logger.addHandler(handler)
+
+
+def get_string_from_url(url):
+    import urllib.request
+    raw_html = urllib.request.urlopen(url).read().decode('utf-8').rstrip()
+    return raw_html
+
+
+def get_humid_and_temp(id):
+    forecastUrl = 'http://' + str(yanpiws_ip) + '/ajax.php?content=humidity&id=' + str(id)
+    return json.loads(get_string_from_url(forecastUrl))
+
+
+def get_forecast():
+    forecastUrl = 'http://' + str(yanpiws_ip) + '/ajax.php?content=forecast_full_json'
+    return json.loads(get_string_from_url(forecastUrl))
+
+
+def get_sun_times():
+    forecastUrl = 'http://' + str(yanpiws_ip) + '/ajax.php?content=sunset'
+
+    sunset = json.loads(get_string_from_url(forecastUrl))
+    forecastUrl = 'http://' + str(yanpiws_ip) + '/ajax.php?content=sunrise'
+
+    sunrise = json.loads(get_string_from_url(forecastUrl))
+    return str(sunrise['sunrise']) + "  -  " + str(sunset['sunset'])
+
+
+def show_info(device):
+    my_logger.debug("Weathercaster: remote_all start")
+
+    # fetch the cooked up json -> strings
+    humid_and_temp1 = get_humid_and_temp(yanpiws_temp_1)
+    forecast = get_forecast()
+    first_line = get_sun_times()
+    second_line = ''
+    third_line = ''
+
+    if humid_and_temp1[0]['temp'] != 'NA':
+        second_line = str(int(float(humid_and_temp1[0]['temp']))) + '°' + humid_and_temp1[0]['label']
+
+    if forecast[0]:
+        third_line = str(int(float(forecast[0]['temperatureMax']))) + '°' + forecast[0]['icon']
+
+    full_path = os.path.dirname(os.path.abspath(__file__)) + "/"
+    font2 = ImageFont.truetype(full_path + "Lato-Heavy.ttf", 12)
+    font1 = ImageFont.truetype(full_path + "Lato-Heavy.ttf", 20)
+
+    my_logger.debug("Weathercaster: remote_all draw")
+
+    with canvas(device) as draw:
+        # draw.rectangle(device.bounding_box, outline="white", fill="black")
+        draw.text((0, 0), first_line, font=font2, fill="white")
+        draw.text((0, 17), second_line, font=font1, fill="white")
+        draw.text((0, 41), third_line, font=font1, fill="white")
+
+
+def full_stack():
+    import traceback, sys
+    exc = sys.exc_info()[0]
+    stack = traceback.extract_stack()[:-1]  # last one would be full_stack()
+    if exc is not None:  # i.e. an exception is present
+        del stack[-1]  # remove call of full_stack, the printed exception
+        # will contain the caught exception caller instead
+    trc = 'Traceback (most recent call last):\n'
+    stackstr = trc + ''.join(traceback.format_list(stack))
+    if exc is not None:
+        stackstr += '  ' + traceback.format_exc().lstrip(trc)
+    return stackstr
+
+
+def main(device):
+    while True:
+        show_info(device)
+        time.sleep(300)
+
+
+if __name__ == "__main__":
+    try:
+        my_logger.debug('Weathercaster: remote_all Starting ')
+        serial = i2c(port=bus_number, address=0x3C)
+        device = ssd1306(serial)
+
+        main(device)
+    except KeyboardInterrupt:
+        my_logger.debug("Weathercaster: remote_all Stopping(Ctrl + C) ")
+        pass
+    finally:
+        my_logger.debug("Weathercaster remote_all exit trace: " + full_stack())

--- a/I2C.bme280.oled/simple_remote.py
+++ b/I2C.bme280.oled/simple_remote.py
@@ -14,6 +14,7 @@ import time
 from dateutil import tz
 import requests
 from datetime import datetime
+import traceback, sys
 
 WAIT = 120
 
@@ -105,7 +106,6 @@ def show_info(yanpiws_ajax_url, yanpiws_temp_1, device):
 
 
 def full_stack():
-    import traceback, sys
     exc = sys.exc_info()[0]
     stack = traceback.extract_stack()[:-1]  # last one would be full_stack()
     if not exc:  # i.e. an exception is present

--- a/I2C.bme280.oled/simple_remote.py
+++ b/I2C.bme280.oled/simple_remote.py
@@ -173,8 +173,6 @@ if __name__ == "__main__":
 
     except KeyboardInterrupt:
         my_logger.debug("Weathercaster: simple Stopping(Ctrl + C) ")
-        pass
-
 
     finally:
         my_logger.debug("Weathercaster simple exit trace: " + full_stack())

--- a/I2C.bme280.oled/simple_remote.py
+++ b/I2C.bme280.oled/simple_remote.py
@@ -17,9 +17,10 @@ from datetime import datetime
 import traceback, sys
 
 WAIT = 120
+ADDRESS = 0x76  # can also be 0x77 - check  i2cdetect -y 1 or i2cdetect -y 0
 
-def post_to_yanpiws(yanpiws_ip, calibration_params, bus, address):
-    data = bme280.sample(bus, address, calibration_params)
+def post_to_yanpiws(yanpiws_ip, calibration_params, bus):
+    data = bme280.sample(bus, ADDRESS, calibration_params)
     temperature_celsius = data.temperature
     temperature_fahrenheit = round((temperature_celsius * 9 / 5) + 32, 2)
     url = f'http://{str(yanpiws_ip)}/parse_and_save.php'
@@ -144,13 +145,12 @@ def main():
         last_seen_temp = 0.0
 
         # BME280 sensor address (default address), Initialize I2C bus and calibration
-        address = 0x76  # can also be 0x77 - check  i2cdetect -y 1 or i2cdetect -y 0
         bus = smbus2.SMBus(1)  # can also be 0, depends on where you found device on per i2cdetect
-        calibration_params = bme280.load_calibration_params(bus, address)
+        calibration_params = bme280.load_calibration_params(bus, ADDRESS)
 
         serial = i2c(port=args.bus, address=0x3C)
         device = ssd1306(serial)
-        post_to_yanpiws(yanpiws_ip, calibration_params, bus, address)
+        post_to_yanpiws(yanpiws_ip, calibration_params, bus)
         show_info(yanpiws_ajax_url, yanpiws_temp_1, device)
         time.sleep(WAIT)
 

--- a/I2C.bme280.oled/simple_remote.py
+++ b/I2C.bme280.oled/simple_remote.py
@@ -21,7 +21,7 @@ def post_to_yanpiws():
     data = bme280.sample(bus, address, calibration_params)
     temperature_celsius = data.temperature
     temperature_fahrenheit = round((temperature_celsius * 9 / 5) + 32, 2)
-    url = 'http://' + str(yanpiws_ip) + '/parse_and_save.php'
+    url = f'http://{str(yanpiws_ip)}/parse_and_save.php'
     data = {
         "model" : "BMP280",
         "time" : datetime.now(tz=tz.tzlocal()).strftime("%Y-%m-%d %H:%M:%S"),
@@ -33,6 +33,7 @@ def post_to_yanpiws():
     last_seen_temp = temperature_fahrenheit
     requests.post(url, data=data)
 
+
 def get_string_from_url(url):
     import urllib.request
     raw_html = urllib.request.urlopen(url).read().decode('utf-8').rstrip()
@@ -40,31 +41,29 @@ def get_string_from_url(url):
 
 
 def get_remote_humid_and_temp(id):
-    forecast_url = yanpiws_ajax_url + 'humidity&id=' + str(id)
+    forecast_url = f'{yanpiws_ajax_url}humidity&id={str(id)}'
     return json.loads(get_string_from_url(forecast_url))
 
 
 def get_remote_forecast():
-    forecast_url = yanpiws_ajax_url + 'forecast_full_json'
+    forecast_url = f'{yanpiws_ajax_url}forecast_full_json'
     return json.loads(get_string_from_url(forecast_url))
 
 
 def get_remote_sun():
-    data = json.loads(get_string_from_url(yanpiws_ajax_url + "sunrise"))
-    data.update(json.loads(get_string_from_url(yanpiws_ajax_url + "sunset")))
-    return "☀ ↑" + str(data['sunrise']) + " ↓" + str(data['sunset'])
+    data = json.loads(get_string_from_url(f'{yanpiws_ajax_url}sunrise'))
+    data.update(json.loads(get_string_from_url(f'{yanpiws_ajax_url}sunset')))
+    return f'☀ ↑{str(data["sunrise"])} ↓{str(data["sunset"])}'
 
 
 def get_remote_moon():
-    data = json.loads(get_string_from_url(yanpiws_ajax_url + "moonset"))
-    data.update(json.loads(get_string_from_url(yanpiws_ajax_url + "moonrise")))
+    data = json.loads(get_string_from_url(f'{yanpiws_ajax_url}moonset'))
+    data.update(json.loads(get_string_from_url(f'{yanpiws_ajax_url}moonrise')))
     result = '○'
     if data['moonrise']:
-        result = result + " ↑" + data['moonrise']
+        result += f' ↑{data["moonrise"]}'
     if data['moonset']:
-        result = result + " ↓" + data['moonset']
-
-    my_logger.debug('moon data debug: ' + result)
+        result += f' ↓{data["moonset"]}'
     return result
 
 
@@ -84,9 +83,9 @@ def show_info(wait):
         forecast = get_remote_forecast()
         first_line = get_remote_sun()
     except Exception as e:
-        first_line = 'Err ' + str(time.time())
+        first_line = 'Error - check logs :( '
         no_error = False
-        my_logger.debug(f"Weathercaster error on boot: " + str(e))
+        my_logger.debug(f'Weathercaster error on boot: {str(e)}')
 
     if no_error and humid_and_temp1[0]['temp'] != 'NA':
         second_line = str(int(float(humid_and_temp1[0]['temp']))) + '°' + humid_and_temp1[0]['label']
@@ -149,7 +148,7 @@ if __name__ == "__main__":
         parser.add_argument('--temp_id1', '-id1', default='143', type=int, help='remote temp ID #1, defaults to 143')
 
         args = parser.parse_args()
-        
+
         # Build URL and set some vars
         yanpiws_ip = args.remote_ip
         yanpiws_temp_1 = args.temp_id1

--- a/I2C.bme280.oled/simple_remote.py
+++ b/I2C.bme280.oled/simple_remote.py
@@ -6,7 +6,6 @@ from luma.core.render import canvas
 from luma.oled.device import ssd1306
 from PIL import ImageFont
 import argparse
-import json
 import logging.handlers
 import smbus2
 import bme280
@@ -34,30 +33,25 @@ def post_to_yanpiws():
     requests.post(url, data=data)
 
 
-def get_string_from_url(url):
-    raw_html = requests.get(url).content
-    return raw_html
-
-
 def get_remote_humid_and_temp(id):
     forecast_url = f'{yanpiws_ajax_url}humidity&id={str(id)}'
-    return json.loads(get_string_from_url(forecast_url))
+    return requests.get(forecast_url).json()
 
 
 def get_remote_forecast():
     forecast_url = f'{yanpiws_ajax_url}forecast_full_json'
-    return json.loads(get_string_from_url(forecast_url))
+    return requests.get(forecast_url).json()
 
 
 def get_remote_sun():
-    data = json.loads(get_string_from_url(f'{yanpiws_ajax_url}sunrise'))
-    data.update(json.loads(get_string_from_url(f'{yanpiws_ajax_url}sunset')))
+    data = requests.get(f'{yanpiws_ajax_url}sunrise').json()
+    data.update(requests.get(f'{yanpiws_ajax_url}sunset').json())
     return f'☀ ↑{str(data["sunrise"])} ↓{str(data["sunset"])}'
 
 
 def get_remote_moon():
-    data = json.loads(get_string_from_url(f'{yanpiws_ajax_url}moonset'))
-    data.update(json.loads(get_string_from_url(f'{yanpiws_ajax_url}moonrise')))
+    data = requests.get(f'{yanpiws_ajax_url}moonset').json()
+    data.update(requests.get(f'{yanpiws_ajax_url}moonrise').json())
     result = '○'
     if data['moonrise']:
         result += f' ↑{data["moonrise"]}'


### PR DESCRIPTION
This PR enables a new style of I2C script which:
* largely copies [existing script](https://github.com/mrjones-plip/YANPIWS/blob/master/I2C.bme280.oled/remote_temps_humid.py), so has nothing too new, but also has poor code re-use :(
* has just 3 lines instead of 4.  the 3 are much more legible 
* also reads temps from BME280 sensor and then does a `POST` to YANPIWs server
* has some hard coded items, but they're called out with a `todo` flag.  we'll live today to fight tomorrow.